### PR TITLE
fix: restore homepage routing by building on Vercel

### DIFF
--- a/.github/workflows/vercelProduction.yml
+++ b/.github/workflows/vercelProduction.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
@@ -24,7 +25,5 @@ jobs:
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.ALEX_VERCEL_TOKEN }}
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.ALEX_VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.ALEX_VERCEL_TOKEN }}
+        run: vercel deploy --prod --token=${{ secrets.ALEX_VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "next build",
+  "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Problem

Production is serving **404 at `/`** while the homepage is live at `/index`:

| Path | Result |
|---|---|
| `/` | 404 (12,299 B — the export's `404.html`) |
| `/index` | 200 (74,907 B — the real homepage) |
| `/privacy` | 200 |

The v0.10.0 deploy (#31) succeeded and the artifact is correct — I rebuilt `87c4eae` locally and it emits `out/index.html` at exactly 74,907 bytes and `out/404.html` at exactly 12,299 bytes, matching the byte counts served in production. Nothing is missing from the build.

The failure is in the routing config: `index.html` got bound to `/index` instead of the site root, so `/` falls through to `404.html`. This is Vercel-side, not the reverse proxy in front of `ecash.love` — the alias `ecash-app-site.vercel.app` reproduces it directly with `server: Vercel` and no nginx in the chain.

## Fix

- **`vercel.json`** pins `"framework": "nextjs"`, so the preset is set from the repo rather than depending on dashboard project settings.
- **Deploy from source** instead of uploading a prebuilt output — drops the `vercel build` step and the `--prebuilt` flag so Vercel's own Next.js pipeline generates the routing config. This is the equivalent of clicking "Redeploy" in the dashboard.
- **`workflow_dispatch:`** added so production can be redeployed without an empty commit (the repo currently does this via #16, #17, #18, #20).

## Verification

The preview build for this branch passed, confirming `vercel.json` doesn't break the build. Preview deployments are SSO-gated, so the routing change itself can only be confirmed once this is on `main`. Post-merge check:

```bash
curl -sS -o /dev/null -w "%{http_code}\n" -A "Mozilla/5.0" https://ecash-app-site.vercel.app/
```

Expect `200`; it is `404` today.

Note the production workflow's source-side deploy path has not run before, so the merge is its first execution. If it fails, the current deployment stays on the alias — the failure mode is "still broken," not "newly broken."

🤖 Generated with [Claude Code](https://claude.com/claude-code)